### PR TITLE
スポンサーのロゴリンク更新など

### DIFF
--- a/src/assets/data/devfest2019.json
+++ b/src/assets/data/devfest2019.json
@@ -9,7 +9,7 @@
             "link": "https://www.uec.ac.jp/"
         },
         {
-            "name": "Peatix",
+            "name": "Peatix Japan株式会社",
             "designation": "メディアパートナー",
             "logo": "https://storage.googleapis.com/gdg-tokyo-website.appspot.com/devfest19/sponsor/peatix.png",
             "link": "https://peatix.com/"
@@ -21,7 +21,7 @@
             "link": "https://developers.google.com/"
         },
         {
-            "name": "grouB",
+            "name": "グローブ・エモーションズ株式会社",
             "designation": "",
             "logo": "https://storage.googleapis.com/gdg-tokyo-website.appspot.com/devfest19/sponsor/grouB.png",
             "link": "https://www.growb.co.jp/"
@@ -51,13 +51,13 @@
     ],
     "Sponsors": [
         {
-            "name": "Circle CI",
+            "name": "CircleCI",
             "logo": "https://storage.googleapis.com/gdg-tokyo-website.appspot.com/devfest19/sponsor/circleci.png",
             "designation": "gold",
             "link": "https://circleci.com/"
         },
         {
-            "name": "DeNA",
+            "name": "株式会社ディー・エヌ・エー",
             "logo": "https://storage.googleapis.com/gdg-tokyo-website.appspot.com/devfest19/sponsor/DeNA.png",
             "designation": "platinum",
             "link": "https://dena.com/"

--- a/src/assets/data/devfest2019.json
+++ b/src/assets/data/devfest2019.json
@@ -5,25 +5,25 @@
         {
             "name": "国立大学法人電気通信大学",
             "designation": "協賛",
-            "logo": "https://storage.googleapis.com/gdg-tokyo-website.appspot.com/devfest19/sponsor/uec.png",
+            "logo": "https://storage.googleapis.com/gdgtokyo_img/devfest19/sponsor/uec.png",
             "link": "https://www.uec.ac.jp/"
         },
         {
             "name": "Peatix Japan株式会社",
             "designation": "メディアパートナー",
-            "logo": "https://storage.googleapis.com/gdg-tokyo-website.appspot.com/devfest19/sponsor/peatix.png",
+            "logo": "https://storage.googleapis.com/gdgtokyo_img/devfest19/sponsor/peatix.png",
             "link": "https://peatix.com/"
         },
         {
             "name": "Google Developers",
             "designation": "協力",
-            "logo": "https://storage.googleapis.com/gdg-tokyo-website.appspot.com/devfest19/sponsor/google_developers.png",
+            "logo": "https://storage.googleapis.com/gdgtokyo_img/devfest19/sponsor/google_developers.png",
             "link": "https://developers.google.com/"
         },
         {
             "name": "グローブ・エモーションズ株式会社",
             "designation": "",
-            "logo": "https://storage.googleapis.com/gdg-tokyo-website.appspot.com/devfest19/sponsor/grouB.png",
+            "logo": "https://storage.googleapis.com/gdgtokyo_img/devfest19/sponsor/grouB.png",
             "link": "https://www.growb.co.jp/"
         }
     ],
@@ -52,13 +52,13 @@
     "Sponsors": [
         {
             "name": "CircleCI",
-            "logo": "https://storage.googleapis.com/gdg-tokyo-website.appspot.com/devfest19/sponsor/circleci.png",
+            "logo": "https://storage.googleapis.com/gdgtokyo_img/devfest19/sponsor/circleci.png",
             "designation": "gold",
             "link": "https://circleci.com/"
         },
         {
             "name": "株式会社ディー・エヌ・エー",
-            "logo": "https://storage.googleapis.com/gdg-tokyo-website.appspot.com/devfest19/sponsor/DeNA.png",
+            "logo": "https://storage.googleapis.com/gdgtokyo_img/devfest19/sponsor/DeNA.png",
             "designation": "platinum",
             "link": "https://dena.com/"
         }

--- a/src/components/devfest2019/DevFestSponsor.vue
+++ b/src/components/devfest2019/DevFestSponsor.vue
@@ -75,6 +75,7 @@
           <v-img
             :src="item.logo"
             :lazy-src="item.logo"
+            :alt="item.name"
           >
             <v-layout slot="placeholder" fill-height align-center justify-center ma-0>
               <v-progress-circular indeterminate color="grey lighten-5"></v-progress-circular>
@@ -106,6 +107,7 @@
           <v-img
             :src="item.logo"
             :lazy-src="item.logo"
+            :alt="item.name"
           >
             <v-layout slot="placeholder" fill-height align-center justify-center ma-0>
               <v-progress-circular indeterminate color="grey lighten-5"></v-progress-circular>

--- a/src/components/devfest2019/DevFestSponsor.vue
+++ b/src/components/devfest2019/DevFestSponsor.vue
@@ -43,6 +43,7 @@
           <v-img
             :src="item.logo"
             :lazy-src="item.logo"
+            :alt="item.name"
           >
             <v-layout slot="placeholder" fill-height align-center justify-center ma-0>
               <v-progress-circular indeterminate color="grey lighten-5"></v-progress-circular>


### PR DESCRIPTION
初PR 💪 ローカル起動での動作確認済みです。

* 画像を配置するGCPのバケットを変えたため、スポンサーのロゴリンク先をその変更に追従した
* alter textとして企業名を指定するようにした
* 企業名をalter textで指定するにあたり、正式名称に更新した