### PR TITLE
DevFest関連ページだけヘッダーを切り分ける

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,25 +6,6 @@
     <CoreView/>
     <CoreFooter/>
     <BottomNav/>
-
-    <!-- <v-toolbar app>
-      <v-toolbar-title class="headline text-uppercase">
-        <span>Vuetify</span>
-        <span class="font-weight-light">MATERIAL DESIGN</span>
-      </v-toolbar-title>
-      <v-spacer></v-spacer>
-      <v-btn
-        flat
-        href="https://github.com/vuetifyjs/vuetify/releases/latest"
-        target="_blank"
-      >
-        <span class="mr-2">Latest Release</span>
-      </v-btn>
-    </v-toolbar>
-
-    <v-content>
-      <HelloWorld/>
-    </v-content> -->
   </v-app>
 </template>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app class="white">
-
-    <CoreToolbar/>
+    <CoreToolbar v-show="$route.name.indexOf('devfest') == -1"/>
+    <DevFestToolbar v-show="$route.name.indexOf('devfest') >= 0"/>
     <CoreDrawer/>
     <CoreView/>
     <CoreFooter/>
@@ -15,6 +15,7 @@ import CoreToolbar from '@/components/common/Toolbar'
 import CoreFooter from '@/components/common/Footer'
 import CoreView from '@/components/common/View'
 import BottomNav from '@/components/common/BottomNav'
+import DevFestToolbar from '@/components/devfest2019/DevFestToolbar'
 
 export default {
   name: 'App',
@@ -23,7 +24,8 @@ export default {
     CoreToolbar,
     CoreFooter,
     CoreView,
-    BottomNav
+    BottomNav,
+    DevFestToolbar
   },
   data () {
     return {

--- a/src/components/devfest2019/DevFestToolbar.vue
+++ b/src/components/devfest2019/DevFestToolbar.vue
@@ -13,7 +13,22 @@
     <v-toolbar-title class="ml-0 pl-1 mr-1">
       <span class="google-font"><a href="#" style="text-decoration:none; color:black;">GDG DevFest Tokyo 2019</a></span>
     </v-toolbar-title>
+    <!--
+    FIXME:cannot link by id (#speaker, #sponsor)
     <v-spacer />
+        <v-btn
+        v-for="(link, i) in devfestLinks"
+        :key="i"
+        :to="link.to"
+        class="ml-0 google-font hidden-sm-and-down"
+        style="text-transform: capitalize;"
+        flat
+        :color="link.color"
+        @click="onClick($event, link)"
+      >
+        {{ link.text }}
+    </v-btn>
+    -->
     <v-btn text flat color="blue" :href="devfestInfo.EntryPageUrl">Registration</v-btn>
   </v-toolbar>
 </template>

--- a/src/components/devfest2019/DevFestToolbar.vue
+++ b/src/components/devfest2019/DevFestToolbar.vue
@@ -1,0 +1,46 @@
+<template>
+  <v-toolbar
+    app
+    color="white"
+    height="55px"
+    fixed
+  >
+    <v-toolbar-side-icon
+      class="hidden-md-and-up"
+      @click="toggleDrawer"
+
+    />
+    <v-toolbar-title class="ml-0 pl-1 mr-1">
+      <span class="google-font"><a href="#" style="text-decoration:none; color:black;">GDG DevFest Tokyo 2019</a></span>
+    </v-toolbar-title>
+    <v-spacer />
+    <v-btn text flat color="blue" :href="devfestInfo.EntryPageUrl">Registration</v-btn>
+  </v-toolbar>
+</template>
+
+<script>
+import DevFestInfo from "@/assets/data/devfest2019.json";
+  // Utilities
+  import {
+    mapGetters,
+    mapMutations
+  } from 'vuex'
+  export default {
+    data() {
+      return {
+        devfestInfo: DevFestInfo
+      }
+    },
+    computed: {
+      ...mapGetters(['devfestLinks'])
+    },
+    methods: {
+      ...mapMutations(['toggleDrawer']),
+      onClick (e, item) {
+        e.stopPropagation()
+        if (item.to || !item.href) return
+        this.$vuetify.goTo(item.href)
+      }
+    }
+  }
+</script>

--- a/src/components/devfest2019/DevFestToolbar.vue
+++ b/src/components/devfest2019/DevFestToolbar.vue
@@ -13,9 +13,9 @@
     <v-toolbar-title class="ml-0 pl-1 mr-1">
       <span class="google-font"><a href="#" style="text-decoration:none; color:black;">GDG DevFest Tokyo 2019</a></span>
     </v-toolbar-title>
+    <v-spacer />
     <!--
     FIXME:cannot link by id (#speaker, #sponsor)
-    <v-spacer />
         <v-btn
         v-for="(link, i) in devfestLinks"
         :key="i"

--- a/src/store.js
+++ b/src/store.js
@@ -13,11 +13,19 @@ export default new Vuex.Store({
       { text: 'Team', to: '/team', icon:'group'},
       { text: 'About', to: '/about', icon: 'toc'},
       { text: 'Contact', to: '/contact', icon:'person'}
+    ],
+    devfestItems: [
+      { text: 'Speaker', to: '/devfest2019#speaker', icon: 'favorite'},
+      { text: 'Sponsor', to: '/devfest2019#sponsor', icon: 'favorite'},
+      // { text: 'Sessions', to: '/devfest2019/sessions', icon: 'favorite'},
     ]
   },
   getters:{
     links: (state) => {
       return state.items
+    },
+    devfestLinks: (state) => {
+      return state.devfestItems
     }
   },
   mutations: {

--- a/src/views/DevFest2019.vue
+++ b/src/views/DevFest2019.vue
@@ -23,7 +23,7 @@
     <v-container fluid style="background-color:#F9F9F9">
       <v-layout wrap align-center justify-center row fill-height>
         <v-flex xs12 md10>
-          <DevFestSpeaker />
+          <DevFestSpeaker id="speaker"/>
         </v-flex>
       </v-layout>
     </v-container>
@@ -39,7 +39,7 @@
     <v-container fluid class="my-4">
       <v-layout wrap align-center justify-center row fill-height>
         <v-flex xs12 md10>
-          <DevFestSponsor />
+          <DevFestSponsor id="sponsor"/>
         </v-flex>
       </v-layout>
     </v-container>


### PR DESCRIPTION
DevFest関連ページとその他のページで、読み込むHeaderコンポーネントを切り替えました。
DevFestのヘッダーにはとりあえず参加登録のボタンだけ置いてます。
（id指定でspeakerとかsponsorやろうとしてもうまく行かなかったので一旦これだけ・・・）