### PR TITLE
Topic/arrange component order

### DIFF
--- a/src/components/devfest2019/DevFestJoin.vue
+++ b/src/components/devfest2019/DevFestJoin.vue
@@ -4,17 +4,27 @@
       <v-flex xs12 sm12 md12 lg12 class="pa-2 text-xs-center">
         <p class="google-font" style="font-size: 350%; color: white">GDG DevFest Tokyo 2019</p>
       </v-flex>
-      <!-- <v-btn :href="chapterDetails.ChapterMeetupLink" target="_blank" class="ma-0 google-font elevation-1" color="white" style="text-transform: capitalize; border-radius:5px; color:black; padding: 0px 32px">参加する</v-btn> -->
+      <v-flex xs12 sm4 text-xs-center>
+        <div>
+          <v-btn
+            :href="devfestDetails.EntryPageUrl"
+            class="pa-5 ma-0 google-font elevation-1"
+            target="_blank"
+            color="white"
+            style="font-size:150%; text-transform: capitalize; border-radius:5px; color:rgb(26, 115, 232)"
+          >参加申込<br />(Registration)</v-btn>
+        </div>
+      </v-flex>
     </v-layout>
   </v-container>
 </template>
 
 <script>
-import ChapterDetails from "@/assets/data/chapterDetails.json";
+import DevFestDetails from "@/assets/data/devfest2019.json";
 export default {
   data() {
     return {
-      chapterDetails: ChapterDetails
+      devfestDetails: DevFestDetails,
     };
   }
 };

--- a/src/components/devfest2019/DevFestPhoto.vue
+++ b/src/components/devfest2019/DevFestPhoto.vue
@@ -9,11 +9,6 @@
         <v-progress-circular indeterminate color="grey lighten-5"></v-progress-circular>
       </v-layout>
     </v-img>
-    <v-img
-      src="/img/devfest2019/kit/image07.png"
-      lazy-src="/img/devfest2019/kit/image07.png"
-      width="100%"
-    ></v-img>
   </v-layout>
 </template>
 

--- a/src/views/DevFest2019.vue
+++ b/src/views/DevFest2019.vue
@@ -47,7 +47,7 @@
     <v-container fluid class="background-color:#F9F9F9">
       <v-layout wrap align-center justify-center row fill-height>
         <v-flex xs12 md10>
-          <DevFestOrganizer />
+          <DevFestPartner />
         </v-flex>
       </v-layout>
     </v-container>
@@ -55,7 +55,7 @@
     <v-container fluid class="background-color:#F9F9F9">
       <v-layout wrap align-center justify-center row fill-height>
         <v-flex xs12 md10>
-          <DevFestPartner />
+          <DevFestOrganizer />
         </v-flex>
       </v-layout>
     </v-container>


### PR DESCRIPTION
@shoco310 がSlackに画像とともに書いてたので直した
```
1. GDG Tokyoの紹介は協賛とか協力の一番下で良さそう。メディアパートナーとか、協賛とかの方を目立たせた方が良いと思ったので配置換えお願いしたいです。
2. 一番下にDevFestが連呼していたので、今回のデザインバナーは取ってしまい、参加申し込みボタンを一番下に配置していただきたく。
申し込みするのにい上まで戻るのは結構大変。
```
![レイアウト変更](https://user-images.githubusercontent.com/10089070/68351267-44184080-0146-11ea-93d3-393f35b8bb37.png)