### PR TITLE
文言を2020版に修正

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,13 +8,13 @@
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>GDG Tokyo</title>
     <meta name=theme-color content=#0277bd>
-    <meta name="description" content="DevFest は、Google Developer Group (GDG) コミュニティによって世界各地で開かれるデベロッパー向けイベントです。東京では、Android、Google Cloud Platform（GCP）、Web、Firebase、Machine Learning （ML）、Assistant、Flutter、Goといった様々な技術の最新情報や現場でのノウハウを学べるコミュニティイベントとして開催しています。">
+    <meta name="description" content="DevFest は、Google Developer Group (GDG) コミュニティによって世界各地で開かれるデベロッパー向けイベントです。日本では、9つのGDGチャプターとWTMが共催という形で、Android、Google Cloud Platform（GCP）、Web、Firebase、Machine Learning （ML）、Assistant、Flutter、Goといった様々な技術の最新情報や現場でのノウハウを2日で学べるコミュニティイベントとして開催します。">
     <meta name="keywords" content="GDG, Google, Google Developers Groups, Tokyo, GDG Tokyo, DevFest Tokyo, DevFest">
     <!-- OpenGraph Meta Tags -->
-    <meta property="og:title" content="GDG Tokyo | DevFest 2020"/>
+    <meta property="og:title" content="GDG Tokyo"/>
     <meta property="og:type" content="website"/>
     <meta property="og:url" content="https://tokyo.gdgjapan.org"/>
-    <meta property="og:description" content="DevFest は、Google Developer Group (GDG) コミュニティによって世界各地で開かれるデベロッパー向けイベントです。東京では、Android、Google Cloud Platform（GCP）、Web、Firebase、Machine Learning （ML）、Assistant、Flutter、Goといった様々な技術の最新情報や現場でのノウハウを学べるコミュニティイベントとして開催しています。"/>
+    <meta property="og:description" content="DevFest は、Google Developer Group (GDG) コミュニティによって世界各地で開かれるデベロッパー向けイベントです。日本では、9つのGDGチャプターとWTMが共催という形で、Android、Google Cloud Platform（GCP）、Web、Firebase、Machine Learning （ML）、Assistant、Flutter、Goといった様々な技術の最新情報や現場でのノウハウを2日で学べるコミュニティイベントとして開催します。"/>
     <meta property="og:image" content="/img/devfest2020/topimg.jpg"/>
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:creator" content="@gdgtokyo"/>

--- a/public/index.html
+++ b/public/index.html
@@ -8,13 +8,13 @@
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>GDG Tokyo</title>
     <meta name=theme-color content=#0277bd>
-    <meta name="description" content="DevFest は、Google Developer Group (GDG) コミュニティによって世界各地で開かれるデベロッパー向けイベントです。東京では、Android、Google Cloud Platform（GCP）、Web、Firebase、Machine Learning （ML）、Assistant、Flutter、Goといった様々な技術の最新情報や現場でのノウハウを一日で学べるコミュニティイベントとして開催しています。">
+    <meta name="description" content="DevFest は、Google Developer Group (GDG) コミュニティによって世界各地で開かれるデベロッパー向けイベントです。東京では、Android、Google Cloud Platform（GCP）、Web、Firebase、Machine Learning （ML）、Assistant、Flutter、Goといった様々な技術の最新情報や現場でのノウハウを学べるコミュニティイベントとして開催しています。">
     <meta name="keywords" content="GDG, Google, Google Developers Groups, Tokyo, GDG Tokyo, DevFest Tokyo, DevFest">
     <!-- OpenGraph Meta Tags -->
     <meta property="og:title" content="GDG Tokyo | DevFest 2020"/>
     <meta property="og:type" content="website"/>
     <meta property="og:url" content="https://tokyo.gdgjapan.org"/>
-    <meta property="og:description" content="DevFest は、Google Developer Group (GDG) コミュニティによって世界各地で開かれるデベロッパー向けイベントです。東京では、Android、Google Cloud Platform（GCP）、Web、Firebase、Machine Learning （ML）、Assistant、Flutter、Goといった様々な技術の最新情報や現場でのノウハウを一日で学べるコミュニティイベントとして開催しています。"/>
+    <meta property="og:description" content="DevFest は、Google Developer Group (GDG) コミュニティによって世界各地で開かれるデベロッパー向けイベントです。東京では、Android、Google Cloud Platform（GCP）、Web、Firebase、Machine Learning （ML）、Assistant、Flutter、Goといった様々な技術の最新情報や現場でのノウハウを学べるコミュニティイベントとして開催しています。"/>
     <meta property="og:image" content="/img/devfest2020/topimg.jpg"/>
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:creator" content="@gdgtokyo"/>

--- a/src/assets/data/devfest2020.json
+++ b/src/assets/data/devfest2020.json
@@ -1,4 +1,5 @@
 {
+    "EntryPageUrl":"https://gdg-tokyo.connpass.com/event/190079/",
     "Chapters": [
         {
             "name": "GDG Fukushima",

--- a/src/assets/data/devfest2020.json
+++ b/src/assets/data/devfest2020.json
@@ -29,7 +29,7 @@
         {
             "name": "GDG Kyoto",
             "logo": "/img/devfest2020/chapters/GDG Kyoto.png",
-            "detail": "",
+            "detail": "GDG Kyotoではオンライン・オフラインを問わず、勉強会やHackathonのようなイベントを開催しています。イベントでは、Googleのテクノロジーだけでなく、UI/UXデザイン等さまざまなテーマを取り上げています。",
             "socialLinks": [
                 {
                     "name": "Global",
@@ -42,13 +42,19 @@
                     "link": "https://gdgkyoto.connpass.com/",
                     "icon": "fas fa-compass",
                     "color": "red"
+                },
+                {
+                    "name": "Twitter",
+                    "link": "https://twitter.com/gdgkyoto/",
+                    "icon": "fab fa-twitter",
+                    "color": "#1da1f2"
                 }
             ]
         },
         {
             "name": "GDG Kyushu",
             "logo": "/img/devfest2020/chapters/GDG Kyushu.png",
-            "detail": "",
+            "detail": "GDG九州は スマートフォン、Web、プログラム、デザイン、熊本、長崎、佐賀、大分、宮崎、福岡、鹿児島、離れた技術、離れた場所を繋いでいきます。",
             "socialLinks": [
                 {
                     "name": "Global",

--- a/src/components/devfest2020/DevFestAbout.vue
+++ b/src/components/devfest2020/DevFestAbout.vue
@@ -9,7 +9,7 @@
       <v-flex xs12 md9 lg9 class="pa-2 text-xs-left">
         <p
           class="google-font"
-        >DevFest は、Google Developer Group (GDG) コミュニティによって世界各地で開かれるデベロッパー向けイベントです。<br>日本では、9つのGDGチャプターとWTMが共催という形で、Android、Google Cloud Platform（GCP）、Web、Firebase、Machine Learning （ML）、Assistant、Flutter、Goといった様々な技術の最新情報や現場でのノウハウを2日で学べるコミュニティイベントとして開催します。<br>GDG Shinsyu, GDG Fukushima, GDG Tokyo, WTM Tokyo, GDG Kyoto, GDG Osaka, GDG Nagoya, GDG Shikoku, GDG Yamaguchi, GDG Kyusyu</p>
+        >DevFest は、Google Developer Group (GDG) コミュニティによって世界各地で開かれるデベロッパー向けイベントです。東京では、Android、Google Cloud Platform（GCP）、Web、Firebase、Machine Learning （ML）、Assistant、Flutter、Goといった様々な技術の最新情報や現場でのノウハウを学べるコミュニティイベントとして開催しています。<br>GDG Fukushima, GDG Kyoto, GDG Kyusyu, GDG Nagoya, GDG Nara, GDG Osaka, GDG Shinsyu, GDG Tokyo, GDG Yamaguchi, WTM Tokyo</p>
         <p
           class="google-font"
         >The DevFest, or 'Developer Festival', is a technical conference for developers. It is aimed at students, professionals or simply curious techies.</p>

--- a/src/components/devfest2020/DevFestBottomNav.vue
+++ b/src/components/devfest2020/DevFestBottomNav.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card color="white" height="60px" class="white hidden-sm-and-up" flat>
     <v-bottom-nav :active.sync="bottomNav" :value="true" app color="white" class="elevation-2">
-      <v-btn color="#518FF5" flat value="sponsors" router href="/devfest2020#sponsor">
+      <!-- <v-btn color="#518FF5" flat value="sponsors" router href="/devfest2020#sponsor">
         <span>Sponsors</span>
         <v-icon>rounded_corner</v-icon>
       </v-btn>
@@ -9,9 +9,9 @@
       <v-btn color="#518FF5" flat value="speakers" router href="/devfest2020#speaker">
         <span>Speakers</span>
         <v-icon>group</v-icon>
-      </v-btn>
+      </v-btn> -->
 
-      <v-btn color="#518FF5" flat value="schedule" router to="/devfest2020/schedule">
+      <v-btn color="#518FF5" flat value="schedule" router to="/devfest2020#schedule">
         <span>Schedule</span>
         <v-icon>list</v-icon>
       </v-btn>

--- a/src/components/devfest2020/DevFestSchedule.vue
+++ b/src/components/devfest2020/DevFestSchedule.vue
@@ -22,7 +22,7 @@
         <p class="google-font">
           開催場所 : オンライン
         </p>
-        <p style="font-size:130%; font-weight: bold; color: #fabb01;">Android, Flutter, ML</p>
+        <p style="font-size:130%; font-weight: bold; color: #fabb01;">Android, Firebase, Flutter, ML, Assistant, Angular</p>
       </v-flex>
     </v-layout>
     <v-divider></v-divider>
@@ -42,7 +42,7 @@
         <p class="google-font">
           開催場所 : オンライン
         </p>
-        <p style="font-size:130%; font-weight: bold; color: #34a851;">Cloud, GoogleAppScript</p>
+        <p style="font-size:130%; font-weight: bold; color: #34a851;">Google Apps Script, Cloud, Web, Android, Firebase</p>
       </v-flex>
     </v-layout>
     <v-divider></v-divider>

--- a/src/components/devfest2020/DevFestStaff.vue
+++ b/src/components/devfest2020/DevFestStaff.vue
@@ -9,7 +9,7 @@
     <!-- Staff本体 -->
     <v-layout wrap align-center justify-center row fill-height class="my-3">
       <v-flex xs12 md6 lg6 class="pa-2 text-xs-left">
-        <p class="google-font">GDG DevFest2020実行委員会 実行委員長 Shoko Sato(GDG Tokyo)<br>副実行委員長 Hayakawa(GDG Nagoya), 副実行委員長 furushin(GDG Osaka)</p>
+        <p class="google-font">GDG DevFest2020実行委員会 実行委員長 Shoko Sato(GDG Tokyo)<br>副実行委員長 sokume / Tsutomu Hayakawa(GDG Nagoya), 副実行委員長 furushin(GDG Osaka)</p>
       </v-flex>
     </v-layout>
     <!-- チャプター紹介 -->

--- a/src/components/devfest2020/DevFestTop.vue
+++ b/src/components/devfest2020/DevFestTop.vue
@@ -10,24 +10,28 @@
       <v-layout slot="placeholder" fill-height align-center justify-center ma-0>
         <v-progress-circular indeterminate color="grey lighten-5"></v-progress-circular>
       </v-layout>
-      <v-btn
-          :href="devfestDetails.EntryPageUrl"
-          class="pa-5 ma-0 google-font elevation-1"
-          target="_blank"
-          color="#34a851"
-          style="font-size:150%; text-transform: capitalize; border-radius:5px; color:white"
-        >参加申込<br />(Registration)</v-btn>
+      <v-layout wrap align-end justify-center row fill-height class="pb-4">
+        <div>
+          <v-btn
+            :href="devfestDetails.EntryPageUrl"
+            class="pa-4 ma-4 elevation-0 hidden-sm-and-down"
+            target="_blank"
+            color="#1705df"
+            style="font-size:150%; text-transform: capitalize; border-radius:0px; border: 8px solid white; color:white"
+          >Register now</v-btn>
+        </div>
+      </v-layout>
     </v-img>
     <v-flex xs12 sm4 text-xs-center>
-      <!-- <div>
+      <div>
         <v-btn
           :href="devfestDetails.EntryPageUrl"
-          class="pa-5 ma-0 google-font elevation-1"
+          class="pa-4 ma-4 elevation-0 hidden-md-only hidden-lg-and-up"
           target="_blank"
-          color="#34a851"
-          style="font-size:150%; text-transform: capitalize; border-radius:5px; color:white"
-        >参加申込<br />(Registration)</v-btn>
-      </div> -->
+          color="#1705df"
+          style="font-size:150%; text-transform: capitalize; border-radius:0px; border: 5px solid white; color:white"
+        >Register now</v-btn>
+      </div>
       <!-- <br />
       <div>
         <v-btn
@@ -37,7 +41,7 @@
           color="#1a73e8"
           style="font-size:150%; text-transform: capitalize; border-radius:5px; color:white"
         >パンフレット<br />(Pamphlet)</v-btn>
-      </div> -->
+      </div>-->
     </v-flex>
   </v-layout>
   <!-- </v-container> -->
@@ -49,9 +53,9 @@ import Mixin from "@/mixin.js";
 export default {
   data() {
     return {
-      devfestDetails: DevFestDetails
+      devfestDetails: DevFestDetails,
     };
   },
-  mixins: [Mixin]
+  mixins: [Mixin],
 };
 </script>

--- a/src/components/devfest2020/DevFestTop.vue
+++ b/src/components/devfest2020/DevFestTop.vue
@@ -10,6 +10,13 @@
       <v-layout slot="placeholder" fill-height align-center justify-center ma-0>
         <v-progress-circular indeterminate color="grey lighten-5"></v-progress-circular>
       </v-layout>
+      <v-btn
+          :href="devfestDetails.EntryPageUrl"
+          class="pa-5 ma-0 google-font elevation-1"
+          target="_blank"
+          color="#34a851"
+          style="font-size:150%; text-transform: capitalize; border-radius:5px; color:white"
+        >参加申込<br />(Registration)</v-btn>
     </v-img>
     <v-flex xs12 sm4 text-xs-center>
       <!-- <div>

--- a/src/router.js
+++ b/src/router.js
@@ -16,13 +16,13 @@ const router = new Router({
   routes: [
     {
       path: '/',
-      name: 'home',
+      name: 'route',
       redirect: '/devfest2020',
       // component: Home
     },
     {
       path: '*',
-      name: 'home',
+      name: 'all',
       redirect: '/devfest2020',
       // component: Home
     },
@@ -79,7 +79,7 @@ const router = new Router({
     },
     {
       path: '/devfest2020',
-      name: 'devfest',
+      name: 'devfest2020',
       component: () => import('./views/DevFest2020.vue'),
       meta: { title: 'DevFest2020 | GDG Tokyo', description: 'DevFest は、Google Developer Group (GDG) コミュニティによって世界各地で開かれるデベロッパー向けイベントです。東京では、Android、Google Cloud Platform（GCP）、Web、Firebase、Machine Learning （ML）、Assistant、Flutter、Goといった様々な技術の最新情報や現場でのノウハウを一日で学べるコミュニティイベントとして開催しています。' }
     },

--- a/src/views/DevFest2020.vue
+++ b/src/views/DevFest2020.vue
@@ -15,7 +15,7 @@
     <v-container fluid class="my-4">
       <v-layout wrap align-center justify-center row fill-height>
         <v-flex xs12 md10>
-          <DevFestSchedule />
+          <DevFestSchedule id="schedule" />
         </v-flex>
       </v-layout>
     </v-container>


### PR DESCRIPTION
表示テキストの更新

- about
`
DevFest は、Google Developer Group (GDG) コミュニティによって世界各地で開かれるデベロッパー向けイベントです。東京では、Android、Google Cloud Platform（GCP）、Web、Firebase、Machine Learning （ML）、Assistant、Flutter、Goといった様々な技術の最新情報や現場でのノウハウを学べるコミュニティイベントとして開催しています。
`

- チャプター並び替え
`
GDG Fukushima, GDG Kyoto, GDG Kyusyu, GDG Nagoya, GDG Nara, GDG Osaka, GDG Shinsyu, GDG Tokyo, GDG Yamaguchi, WTM Tokyo
`

- 申し込みページ
`
https://gdg-tokyo.connpass.com/event/190079/
`