### PR TITLE
Direct access to each session information dialog.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 /dist
 tempKey.js
 src/config/
+yarn.lock
 
 # local env files
 .env.local
@@ -12,6 +13,7 @@ src/config/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+firebase-debug.log
 
 # Editor directories and files
 .idea

--- a/src/components/devfest2020/schedule/Schedule.vue
+++ b/src/components/devfest2020/schedule/Schedule.vue
@@ -1,55 +1,55 @@
 <template>
-  <v-dialog v-model="dialog">
-    <template v-slot:activator="{ on }">
-      <div v-on="on">
-        <ScheduleRow :sdata="sdata" />
-      </div>
-    </template>
-    <v-card>
-      <v-card-title class="headline grey lighten-2" primary-title>{{sdata.title}}</v-card-title>
-      <v-divider></v-divider>
-      <v-layout wrap row fill-height justify-center class="pa-4">
-        <v-flex xs12 sm10 md3 lg2 class="pa-2">
-          <v-responsive :aspect-ratio="1/1">
-            <v-avatar size="100%">
-              <v-img
-                  :src="sdata.profileImage"
-                  :lazy-src="sdata.profileImage"
-              >
-                <v-layout
-                    slot="placeholder"
-                    fill-height
-                    align-center
-                    justify-center
-                    ma-0
+  <div>
+    <div v-on:click="handleSessionClick">
+      <ScheduleRow :sdata="sdata" />
+    </div>
+    <v-dialog v-model="dialog">
+      <v-card>
+        <v-card-title class="headline grey lighten-2" primary-title>{{sdata.title}}</v-card-title>
+        <v-divider></v-divider>
+        <v-layout wrap row fill-height justify-center class="pa-4">
+          <v-flex xs12 sm10 md3 lg2 class="pa-2">
+            <v-responsive :aspect-ratio="1/1">
+              <v-avatar size="100%">
+                <v-img
+                    :src="sdata.profileImage"
+                    :lazy-src="sdata.profileImage"
                 >
-                  <v-progress-circular indeterminate color="grey lighten-5"></v-progress-circular>
-                </v-layout>
-              </v-img>
-            </v-avatar>
-          </v-responsive>
-        </v-flex>
-        <v-flex xs12 sm12 md9 lg10 class="pa-2">
-          <v-card-text>
-            <p style="white-space:pre-wrap; word-wrap:break-word;">{{sdata.speakerName}}</p>
-            <p style="white-space:pre-wrap; word-wrap:break-word;">{{sdata.profile}}</p>
-          </v-card-text>
-        </v-flex>
-      </v-layout>
-      <v-divider></v-divider>
-      <v-layout wrap row fill-height justify-center class="pa-4">
-        <v-spacer></v-spacer>
-        <v-flex xs12 sm12 md9 lg10 class="pa-2">
-          <v-card-text>
-            <p>セッション概要</p>
-            <p
-                style="white-space:pre-wrap; word-wrap:break-word;"
-            >{{sdata.description}}</p>
-          </v-card-text>
-        </v-flex>
-      </v-layout>
-    </v-card>
-  </v-dialog>
+                  <v-layout
+                      slot="placeholder"
+                      fill-height
+                      align-center
+                      justify-center
+                      ma-0
+                  >
+                    <v-progress-circular indeterminate color="grey lighten-5"></v-progress-circular>
+                  </v-layout>
+                </v-img>
+              </v-avatar>
+            </v-responsive>
+          </v-flex>
+          <v-flex xs12 sm12 md9 lg10 class="pa-2">
+            <v-card-text>
+              <p style="white-space:pre-wrap; word-wrap:break-word;">{{sdata.speakerName}}</p>
+              <p style="white-space:pre-wrap; word-wrap:break-word;">{{sdata.profile}}</p>
+            </v-card-text>
+          </v-flex>
+        </v-layout>
+        <v-divider></v-divider>
+        <v-layout wrap row fill-height justify-center class="pa-4">
+          <v-spacer></v-spacer>
+          <v-flex xs12 sm12 md9 lg10 class="pa-2">
+            <v-card-text>
+              <p>セッション概要</p>
+              <p
+                  style="white-space:pre-wrap; word-wrap:break-word;"
+              >{{sdata.description}}</p>
+            </v-card-text>
+          </v-flex>
+        </v-layout>
+      </v-card>
+    </v-dialog>
+  </div>
 </template>
 
 <style>
@@ -68,16 +68,25 @@ export default {
     sdata: {
       type: Object,
       default: null
+    },
+    isDay1: {
+      type: Boolean
     }
   },
   components: {
     ScheduleRow,
   },
   mounted() {
-    if (this.$route.params.id) {
-      if (this.sdata.id === this.$route.params.id) {
+    if (this.$route.params.session_id) {
+      if (this.sdata.id === this.$route.params.session_id) {
         this.dialog = true;
       }
+    }
+  },
+  methods: {
+    handleSessionClick: function() {
+      this.dialog = true;
+      this.$router.push(`/devfest2020/schedule/${this.isDay1 ? 1 : 2}/${this.sdata.id}`);
     }
   }
 };

--- a/src/components/devfest2020/schedule/Schedule.vue
+++ b/src/components/devfest2020/schedule/Schedule.vue
@@ -3,7 +3,7 @@
     <div v-on:click="handleSessionClick">
       <ScheduleRow :sdata="sdata" />
     </div>
-    <v-dialog v-model="dialog">
+    <v-dialog v-model="dialog" @input="dialogClosed">
       <v-card>
         <v-card-title class="headline grey lighten-2" primary-title>{{sdata.title}}</v-card-title>
         <v-divider></v-divider>
@@ -87,6 +87,9 @@ export default {
     handleSessionClick: function() {
       this.dialog = true;
       this.$router.push(`/devfest2020/schedule/${this.isDay1 ? 1 : 2}/${this.sdata.id}`);
+    },
+    dialogClosed() {
+      this.$router.push(`/devfest2020/schedule`);
     }
   }
 };

--- a/src/components/devfest2020/schedule/Schedule.vue
+++ b/src/components/devfest2020/schedule/Schedule.vue
@@ -89,7 +89,7 @@ export default {
       this.$router.push(`/devfest2020/schedule/${this.isDay1 ? 1 : 2}/${this.sdata.id}`);
     },
     dialogClosed() {
-      this.$router.push(`/devfest2020/schedule`);
+      this.$router.push(`/devfest2020/schedule/${this.isDay1 ? 1 : 2}`);
     }
   }
 };

--- a/src/components/devfest2020/schedule/Schedule.vue
+++ b/src/components/devfest2020/schedule/Schedule.vue
@@ -1,0 +1,84 @@
+<template>
+  <v-dialog v-model="dialog">
+    <template v-slot:activator="{ on }">
+      <div v-on="on">
+        <ScheduleRow :sdata="sdata" />
+      </div>
+    </template>
+    <v-card>
+      <v-card-title class="headline grey lighten-2" primary-title>{{sdata.title}}</v-card-title>
+      <v-divider></v-divider>
+      <v-layout wrap row fill-height justify-center class="pa-4">
+        <v-flex xs12 sm10 md3 lg2 class="pa-2">
+          <v-responsive :aspect-ratio="1/1">
+            <v-avatar size="100%">
+              <v-img
+                  :src="sdata.profileImage"
+                  :lazy-src="sdata.profileImage"
+              >
+                <v-layout
+                    slot="placeholder"
+                    fill-height
+                    align-center
+                    justify-center
+                    ma-0
+                >
+                  <v-progress-circular indeterminate color="grey lighten-5"></v-progress-circular>
+                </v-layout>
+              </v-img>
+            </v-avatar>
+          </v-responsive>
+        </v-flex>
+        <v-flex xs12 sm12 md9 lg10 class="pa-2">
+          <v-card-text>
+            <p style="white-space:pre-wrap; word-wrap:break-word;">{{sdata.speakerName}}</p>
+            <p style="white-space:pre-wrap; word-wrap:break-word;">{{sdata.profile}}</p>
+          </v-card-text>
+        </v-flex>
+      </v-layout>
+      <v-divider></v-divider>
+      <v-layout wrap row fill-height justify-center class="pa-4">
+        <v-spacer></v-spacer>
+        <v-flex xs12 sm12 md9 lg10 class="pa-2">
+          <v-card-text>
+            <p>セッション概要</p>
+            <p
+                style="white-space:pre-wrap; word-wrap:break-word;"
+            >{{sdata.description}}</p>
+          </v-card-text>
+        </v-flex>
+      </v-layout>
+    </v-card>
+  </v-dialog>
+</template>
+
+<style>
+</style>
+
+<script>
+import ScheduleRow from "@/components/devfest2020/schedule/ScheduleRow";
+
+export default {
+  data() {
+    return {
+      dialog: false
+    };
+  },
+  props: {
+    sdata: {
+      type: Object,
+      default: null
+    }
+  },
+  components: {
+    ScheduleRow,
+  },
+  mounted() {
+    if (this.$route.params.id) {
+      if (this.sdata.id === this.$route.params.id) {
+        this.dialog = true;
+      }
+    }
+  }
+};
+</script>

--- a/src/components/devfest2020/schedule/ScheduleDay1.vue
+++ b/src/components/devfest2020/schedule/ScheduleDay1.vue
@@ -20,57 +20,7 @@
             <div v-for="(obj,x) in itemp" :key="x" class="white">
               <div v-for="(sdata,key) in sessionsData" :key="key">
                 <div v-if="obj == sdata.id" class="py-3 pl-3">
-                  <v-dialog>
-                    <template v-slot:activator="{ on }">
-                      <div v-on="on">
-                        <ScheduleRow :sdata="sdata" />
-                      </div>
-                    </template>
-                    <v-card>
-                      <v-card-title class="headline grey lighten-2" primary-title>{{sdata.title}}</v-card-title>
-                      <v-divider></v-divider>
-                      <v-layout wrap row fill-height justify-center class="pa-4">
-                        <v-flex xs12 sm10 md3 lg2 class="pa-2">
-                          <v-responsive :aspect-ratio="1/1">
-                            <v-avatar size="100%">
-                              <v-img
-                                :src="sdata.profileImage"
-                                :lazy-src="sdata.profileImage"
-                              >
-                                <v-layout
-                                  slot="placeholder"
-                                  fill-height
-                                  align-center
-                                  justify-center
-                                  ma-0
-                                >
-                                  <v-progress-circular indeterminate color="grey lighten-5"></v-progress-circular>
-                                </v-layout>
-                              </v-img>
-                            </v-avatar>
-                          </v-responsive>
-                        </v-flex>
-                        <v-flex xs12 sm12 md9 lg10 class="pa-2">
-                          <v-card-text>
-                            <p style="white-space:pre-wrap; word-wrap:break-word;">{{sdata.speakerName}}</p>
-                            <p style="white-space:pre-wrap; word-wrap:break-word;">{{sdata.profile}}</p>
-                          </v-card-text>
-                        </v-flex>
-                      </v-layout>
-                      <v-divider></v-divider>
-                      <v-layout wrap row fill-height justify-center class="pa-4">
-                        <v-spacer></v-spacer>
-                        <v-flex xs12 sm12 md9 lg10 class="pa-2">
-                          <v-card-text>
-                            <p>セッション概要</p>
-                            <p
-                              style="white-space:pre-wrap; word-wrap:break-word;"
-                            >{{sdata.description}}</p>
-                          </v-card-text>
-                        </v-flex>
-                      </v-layout>
-                    </v-card>
-                  </v-dialog>
+                  <Schedule :sdata="sdata" />
                 </div>
               </div>
             </div>
@@ -107,9 +57,9 @@
 </style>
 
 <script>
-import ScheduleRow from "@/components/devfest2020/schedule/ScheduleRow";
 import ScheduleData from "@/assets/data/devfest2020schedule.json";
 import SessionData from "@/assets/data/devfest2020session.json";
+import Schedule from "@/components/devfest2020/schedule/Schedule";
 
 export default {
   data: () => ({
@@ -117,7 +67,7 @@ export default {
     sessionsData: SessionData,
   }),
   components: {
-    ScheduleRow,
+    Schedule,
   },
   methods: {
     getBorderColor(data) {

--- a/src/components/devfest2020/schedule/ScheduleDay1.vue
+++ b/src/components/devfest2020/schedule/ScheduleDay1.vue
@@ -20,7 +20,7 @@
             <div v-for="(obj,x) in itemp" :key="x" class="white">
               <div v-for="(sdata,key) in sessionsData" :key="key">
                 <div v-if="obj == sdata.id" class="py-3 pl-3">
-                  <Schedule :sdata="sdata" />
+                  <Schedule :sdata="sdata" :isDay1="true" />
                 </div>
               </div>
             </div>

--- a/src/components/devfest2020/schedule/ScheduleDay2.vue
+++ b/src/components/devfest2020/schedule/ScheduleDay2.vue
@@ -20,57 +20,7 @@
             <div v-for="(obj,x) in itemp" :key="x" class="white">
               <div v-for="(sdata,key) in sessionsData" :key="key">
                 <div v-if="obj == sdata.id" class="py-3 pl-3">
-                  <v-dialog>
-                    <template v-slot:activator="{ on }">
-                      <div v-on="on">
-                        <ScheduleRow :sdata="sdata" />
-                      </div>
-                    </template>
-                    <v-card>
-                      <v-card-title class="headline grey lighten-2" primary-title>{{sdata.title}}</v-card-title>
-                      <v-divider></v-divider>
-                      <v-layout wrap row fill-height justify-center class="pa-4">
-                        <v-flex xs12 sm10 md3 lg2 class="pa-2">
-                          <v-responsive :aspect-ratio="1/1">
-                            <v-avatar size="100%">
-                              <v-img
-                                :src="sdata.profileImage"
-                                :lazy-src="sdata.profileImage"
-                              >
-                                <v-layout
-                                  slot="placeholder"
-                                  fill-height
-                                  align-center
-                                  justify-center
-                                  ma-0
-                                >
-                                  <v-progress-circular indeterminate color="grey lighten-5"></v-progress-circular>
-                                </v-layout>
-                              </v-img>
-                            </v-avatar>
-                          </v-responsive>
-                        </v-flex>
-                        <v-flex xs12 sm12 md9 lg10 class="pa-2">
-                          <v-card-text>
-                            <p style="white-space:pre-wrap; word-wrap:break-word;">{{sdata.speakerName}}</p>
-                            <p style="white-space:pre-wrap; word-wrap:break-word;">{{sdata.profile}}</p>
-                          </v-card-text>
-                        </v-flex>
-                      </v-layout>
-                      <v-divider></v-divider>
-                      <v-layout wrap row fill-height justify-center class="pa-4">
-                        <v-spacer></v-spacer>
-                        <v-flex xs12 sm12 md9 lg10 class="pa-2">
-                          <v-card-text>
-                            <p>セッション概要</p>
-                            <p
-                              style="white-space:pre-wrap; word-wrap:break-word;"
-                            >{{sdata.description}}</p>
-                          </v-card-text>
-                        </v-flex>
-                      </v-layout>
-                    </v-card>
-                  </v-dialog>
+                  <Schedule :sdata="sdata" />
                 </div>
               </div>
             </div>
@@ -107,9 +57,9 @@
 </style>
 
 <script>
-import ScheduleRow from "@/components/devfest2020/schedule/ScheduleRow";
 import ScheduleData from "@/assets/data/devfest2020schedule.json";
 import SessionData from "@/assets/data/devfest2020session.json";
+import Schedule from "@/components/devfest2020/schedule/Schedule";
 
 export default {
   data: () => ({
@@ -117,7 +67,7 @@ export default {
     sessionsData: SessionData,
   }),
   components: {
-    ScheduleRow,
+    Schedule,
   },
   methods: {
     getBorderColor(data) {

--- a/src/components/devfest2020/schedule/ScheduleDay2.vue
+++ b/src/components/devfest2020/schedule/ScheduleDay2.vue
@@ -20,7 +20,7 @@
             <div v-for="(obj,x) in itemp" :key="x" class="white">
               <div v-for="(sdata,key) in sessionsData" :key="key">
                 <div v-if="obj == sdata.id" class="py-3 pl-3">
-                  <Schedule :sdata="sdata" />
+                  <Schedule :sdata="sdata" :isDay1="false" />
                 </div>
               </div>
             </div>

--- a/src/router.js
+++ b/src/router.js
@@ -89,6 +89,11 @@ const router = new Router({
       component: () => import('./views/devfest2020/DevFest2020Schedule.vue'),
       meta: { title: 'DevFest2020 | GDG Tokyo', description: 'DevFest は、Google Developer Group (GDG) コミュニティによって世界各地で開かれるデベロッパー向けイベントです。日本では、9つのGDGチャプターとWTMが共催という形で、Android、Google Cloud Platform（GCP）、Web、Firebase、Machine Learning （ML）、Assistant、Flutter、Goといった様々な技術の最新情報や現場でのノウハウを2日で学べるコミュニティイベントとして開催します。' }
     },
+    {
+      path: '/devfest2020/schedule/:id',
+      name: 'devfest2020_session',
+      component: () => import('./views/devfest2020/DevFest2020Schedule.vue'),
+    },
   ]
 })
 

--- a/src/router.js
+++ b/src/router.js
@@ -90,9 +90,22 @@ const router = new Router({
       meta: { title: 'DevFest2020 | GDG Tokyo', description: 'DevFest は、Google Developer Group (GDG) コミュニティによって世界各地で開かれるデベロッパー向けイベントです。日本では、9つのGDGチャプターとWTMが共催という形で、Android、Google Cloud Platform（GCP）、Web、Firebase、Machine Learning （ML）、Assistant、Flutter、Goといった様々な技術の最新情報や現場でのノウハウを2日で学べるコミュニティイベントとして開催します。' }
     },
     {
-      path: '/devfest2020/schedule/:id',
+      path: '/devfest2020/schedule',
       name: 'devfest2020_session',
       component: () => import('./views/devfest2020/DevFest2020Schedule.vue'),
+      meta: { title: 'DevFest2020 | GDG Tokyo', description: 'DevFest は、Google Developer Group (GDG) コミュニティによって世界各地で開かれるデベロッパー向けイベントです。日本では、9つのGDGチャプターとWTMが共催という形で、Android、Google Cloud Platform（GCP）、Web、Firebase、Machine Learning （ML）、Assistant、Flutter、Goといった様々な技術の最新情報や現場でのノウハウを2日で学べるコミュニティイベントとして開催します。' }
+    },
+    {
+      path: '/devfest2020/schedule/:day',
+      name: 'devfest2020_session',
+      component: () => import('./views/devfest2020/DevFest2020Schedule.vue'),
+      meta: { title: 'DevFest2020 | GDG Tokyo', description: 'DevFest は、Google Developer Group (GDG) コミュニティによって世界各地で開かれるデベロッパー向けイベントです。日本では、9つのGDGチャプターとWTMが共催という形で、Android、Google Cloud Platform（GCP）、Web、Firebase、Machine Learning （ML）、Assistant、Flutter、Goといった様々な技術の最新情報や現場でのノウハウを2日で学べるコミュニティイベントとして開催します。' }
+    },
+    {
+      path: '/devfest2020/schedule/:day/:session_id',
+      name: 'devfest2020_session',
+      component: () => import('./views/devfest2020/DevFest2020Schedule.vue'),
+      meta: { title: 'DevFest2020 | GDG Tokyo', description: 'DevFest は、Google Developer Group (GDG) コミュニティによって世界各地で開かれるデベロッパー向けイベントです。日本では、9つのGDGチャプターとWTMが共催という形で、Android、Google Cloud Platform（GCP）、Web、Firebase、Machine Learning （ML）、Assistant、Flutter、Goといった様々な技術の最新情報や現場でのノウハウを2日で学べるコミュニティイベントとして開催します。' }
     },
   ]
 })

--- a/src/router.js
+++ b/src/router.js
@@ -85,12 +85,6 @@ const router = new Router({
     },
     {
       path: '/devfest2020/schedule',
-      name: 'devfest2020_schedule',
-      component: () => import('./views/devfest2020/DevFest2020Schedule.vue'),
-      meta: { title: 'DevFest2020 | GDG Tokyo', description: 'DevFest は、Google Developer Group (GDG) コミュニティによって世界各地で開かれるデベロッパー向けイベントです。日本では、9つのGDGチャプターとWTMが共催という形で、Android、Google Cloud Platform（GCP）、Web、Firebase、Machine Learning （ML）、Assistant、Flutter、Goといった様々な技術の最新情報や現場でのノウハウを2日で学べるコミュニティイベントとして開催します。' }
-    },
-    {
-      path: '/devfest2020/schedule',
       name: 'devfest2020_session',
       component: () => import('./views/devfest2020/DevFest2020Schedule.vue'),
       meta: { title: 'DevFest2020 | GDG Tokyo', description: 'DevFest は、Google Developer Group (GDG) コミュニティによって世界各地で開かれるデベロッパー向けイベントです。日本では、9つのGDGチャプターとWTMが共催という形で、Android、Google Cloud Platform（GCP）、Web、Firebase、Machine Learning （ML）、Assistant、Flutter、Goといった様々な技術の最新情報や現場でのノウハウを2日で学べるコミュニティイベントとして開催します。' }

--- a/src/views/devfest2020/DevFest2020Schedule.vue
+++ b/src/views/devfest2020/DevFest2020Schedule.vue
@@ -30,6 +30,7 @@
 import ScheduleHeader from "@/components/devfest2020/schedule/Header.vue";
 import ScheduleDay1 from "@/components/devfest2020/schedule/ScheduleDay1.vue";
 import ScheduleDay2 from "@/components/devfest2020/schedule/ScheduleDay2.vue";
+import ScheduleData from "@/assets/data/devfest2020schedule.json";
 export default {
   components: {
     ScheduleHeader,
@@ -48,6 +49,18 @@ export default {
     return {
       isDay1: true
     };
+  },
+  created() {
+    if (this.$route.params.id) {
+      const existInDay2 = ScheduleData.day2.some(data => {
+        return data.sessions.some(session => {
+          return session.item.includes(Number(this.$route.params.id));
+        });
+      });
+      if (existInDay2) {
+        this.changeToDay2();
+      }
+    }
   }
 };
 </script>

--- a/src/views/devfest2020/DevFest2020Schedule.vue
+++ b/src/views/devfest2020/DevFest2020Schedule.vue
@@ -39,10 +39,16 @@ export default {
   },
   methods: {
     changeToDay1() {
-      this.isDay1 = true;
+      if (!this.isDay1) {
+        this.$router.push('/devfest2020/schedule/1');
+        this.isDay1 = true;
+      }
     },
     changeToDay2() {
-      this.isDay1 = false;
+      if (this.isDay1) {
+        this.$router.push('/devfest2020/schedule/2');
+        this.isDay1 = false;
+      }
     }
   },
   data() {
@@ -51,14 +57,19 @@ export default {
     };
   },
   created() {
-    if (this.$route.params.id) {
+    if (this.$route.params.day === '2') {
+      this.isDay1 = false;
+    } else {
+      this.isDay1 = true;
+    }
+    if (this.$route.params.session_id) {
       const existInDay2 = ScheduleData.day2.some(data => {
         return data.sessions.some(session => {
-          return session.item.includes(Number(this.$route.params.id));
+          return session.item.includes(Number(this.$route.params.session_id));
         });
       });
       if (existInDay2) {
-        this.changeToDay2();
+        this.isDay1 = false;
       }
     }
   }


### PR DESCRIPTION
# What is this

This pull request provides a new feature to add a new route definition to open each session information directly with the new path. To open each session information, we can use this new path: `/devfest2020/schedule/:session_id`.

## Notice

This pull request doesn't have an ability to change day1/2 depending on the specified session with the new path above.