### PR TITLE
dialog close時に元のスクロール位置を表示する

### DIFF
--- a/src/components/devfest2020/schedule/Schedule.vue
+++ b/src/components/devfest2020/schedule/Schedule.vue
@@ -111,6 +111,16 @@ export default {
   components: {
     ScheduleRow,
   },
+  watch: {
+    $route(to, from) {
+      const fromSessionId = from.params.session_id;
+      const toSessionId = to.params.session_id;
+
+      if (fromSessionId && toSessionId === undefined) {
+        this.dialog = false;
+      }
+    },
+  },
   mounted() {
     if (this.$route.params.session_id) {
       if (this.sdata.id === this.$route.params.session_id) {
@@ -124,7 +134,7 @@ export default {
       this.$router.push(`/devfest2020/schedule/${this.isDay1 ? 1 : 2}/${this.sdata.id}`);
     },
     dialogClosed() {
-      this.$router.push(`/devfest2020/schedule/${this.isDay1 ? 1 : 2}`);
+      this.$router.back();
     },
     getCoSpeakerData(coSpeakers) {
       if (coSpeakers == null) {


### PR DESCRIPTION
diaglog close時にスクロールトップに戻ってしまう問題を改善してみました。  

■やったこと
  - Vue Router側で?スクロール位置を覚えてくれているみたいだったので、dialogクローズ時は history backする様に修正しました  
  - ブラウザのバックキーでもダイヤログが閉じられるようrouteを監視し、「URLパスにsessionIdあり -> なし」に変化時にdialogをfalseにしました。

※ 以前気になる点としては、ダイヤログ表示時はスクロールトップに戻ってしまっています。。

■動作Gif
<img src="https://user-images.githubusercontent.com/9292002/95018907-5d4ea780-069d-11eb-9137-8c764512a186.gif" width=400px />
