### PR TITLE
OGタグの修正

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
     <meta property="og:type" content="website"/>
     <meta property="og:url" content="https://tokyo.gdgjapan.org"/>
     <meta property="og:description" content="DevFest は、Google Developer Group (GDG) コミュニティによって世界各地で開かれるデベロッパー向けイベントです。日本では、9つのGDGチャプターとWTMが共催という形で、Android、Google Cloud Platform（GCP）、Web、Firebase、Machine Learning （ML）、Assistant、Flutter、Goといった様々な技術の最新情報や現場でのノウハウを2日で学べるコミュニティイベントとして開催します。"/>
-    <meta property="og:image" content="/img/devfest2020/topimg.jpg"/>
+    <meta property="og:image" content="https://tokyo.gdgjapan.org/img/devfest2020/topimg.jpg"/>
     <meta name="twitter:card" content="summary_large_image"/>
     <meta name="twitter:creator" content="@gdgtokyo"/>
     <meta name="twitter:site" content="@gdgtokyo"/>


### PR DESCRIPTION
`og:image` のタグはフルパスじゃないといけないらしいので修正